### PR TITLE
Make initial round

### DIFF
--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -26,8 +26,7 @@ class Tournament < ApplicationRecord
   validates :title, presence: true, uniqueness: true
   validates :number_of_teams, presence: true, numericality: { greater_than_or_equal_to: 2 }
 
-  validate :number_of_teams_is_power_of_2,
-           :no_repeated_members_across_teams,
+  validate :no_repeated_members_across_teams,
            :team_sizes_within_limit,
            :number_of_teams_within_limit
 
@@ -56,14 +55,6 @@ class Tournament < ApplicationRecord
   def all_members_unique?
     ids = teams.map(&:id)
     Team.where(id: ids).joins(:members).group(:user_id).count.values.all? { |num| num == 1 }
-  end
-
-  def number_of_teams_is_power_of_2
-    errors.add(:number_of_teams, "must be a power of 2") unless power_of_2?(number_of_teams)
-  end
-
-  def power_of_2?(number)
-    number && number.nonzero? && (number & (number - 1)).zero?
   end
 
   def team_sizes_within_limit

--- a/app/services/build_tournament_rounds.rb
+++ b/app/services/build_tournament_rounds.rb
@@ -18,12 +18,40 @@ class BuildTournamentRounds
   end
 
   def build_matches_in_first_round
-    teams.each_slice(2) do |first_team, second_team|
-      rounds.first.matches.build(game: game, team_one: first_team, team_two: second_team)
+    teams_in_first_round.each_slice(2) do |first_team, second_team|
+      rounds[0].matches.build(game: game, team_one: first_team, team_two: second_team)
+    end
+    teams_in_second_round.each_slice(2) do |first_team, second_team|
+      rounds[1].matches.build(game: game, team_one: first_team, team_two: second_team)
     end
   end
 
   def number_of_rounds
-    Math.log2(teams.length).to_i
+    Math.log2(teams.length).ceil
+  end
+
+  def teams_in_first_round
+    teams[0, number_of_teams_in_first_round]
+  end
+
+  def teams_in_second_round
+    teams[number_of_teams_in_first_round, number_of_teams_in_second_round]
+  end
+
+  def number_of_teams_in_first_round
+    lower_power_of_two = 2**Math.log2(teams.length).floor
+    if lower_power_of_two == teams.length
+      lower_power_of_two
+    else
+      (teams.length - lower_power_of_two) * 2
+    end
+  end
+
+  def number_of_teams_in_second_round
+    if teams.length.even?
+      teams.length - number_of_teams_in_first_round
+    else
+      teams.length - number_of_teams_in_first_round - 1
+    end
   end
 end

--- a/app/services/create_next_match.rb
+++ b/app/services/create_next_match.rb
@@ -35,8 +35,16 @@ class CreateNextMatch
     @tournament.rounds[@round.number + 1]
   end
 
+  def other_team_in_next_match
+    if other_match_in_pair
+      other_match_in_pair.winning_team if other_match_in_pair.scores.all?
+    else
+      @tournament.teams[(index_in_round + 1) * 2]
+    end
+  end
+
   def other_match_in_pair
-    @round.matches[index_in_round ^ 1]
+    @other_match_in_pair ||= @round.matches[index_in_round ^ 1]
   end
 
   def index_in_round

--- a/app/services/update_match.rb
+++ b/app/services/update_match.rb
@@ -30,7 +30,7 @@ class UpdateMatch
   def tasks_for_tournament
     return [] unless match_scores.all?
     if next_round
-      if other_match_in_pair.scores.all?
+      if other_team_in_next_match
         [CreateNextMatch.new(tournament: @tournament, round: @round, match: @match)]
       else
         []
@@ -56,8 +56,16 @@ class UpdateMatch
     @tournament.rounds[@round.number + 1]
   end
 
+  def other_team_in_next_match
+    if other_match_in_pair
+      other_match_in_pair.winning_team if other_match_in_pair.scores.all?
+    else
+      @tournament.teams[(index_in_round + 1) * 2]
+    end
+  end
+
   def other_match_in_pair
-    @round.matches[index_in_round ^ 1]
+    @other_match_in_pair ||= @round.matches[index_in_round ^ 1]
   end
 
   def index_in_round

--- a/spec/controllers/api/v1/tournaments_controller_spec.rb
+++ b/spec/controllers/api/v1/tournaments_controller_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe Api::V1::TournamentsController, type: :controller do
     end
 
     context "with wrong params" do
-      let(:tournament_params) { attr_for_tournament.merge(number_of_teams: 111) }
+      let(:tournament_params) { attr_for_tournament.merge(number_of_teams: 0) }
 
       it { is_expected.to be_unprocessable }
 
       it "responds with an error" do
         creation
         expect(parsed_body["error"])
-          .to include("Number of teams must be a power of 2")
+          .to include("Number of teams must be greater than or equal to 2")
       end
 
       it "does not store a new match" do

--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -76,29 +76,21 @@ RSpec.describe Tournament, type: :model do
         it { is_expected.to be_invalid }
       end
 
-      context "when even" do
-        context "when a power of two" do
-          let(:number_of_teams) { 4 }
+      context "when two" do
+        let(:number_of_teams) { 2 }
 
-          it { is_expected.to be_valid }
+        it { is_expected.to be_valid }
 
-          context "when lower than the current number of teams" do
-            before { tournament.teams = create_list(:team, number_of_teams + 1) }
-
-            it { is_expected.to be_invalid }
-          end
-
-          context "when greater than to the current number of teams" do
-            before { tournament.teams = create_list(:team, number_of_teams - 1) }
-
-            it { is_expected.to be_valid }
-          end
-        end
-
-        context "when not a power of two" do
-          let(:number_of_teams) { 6 }
+        context "when lower than the current number of teams" do
+          before { tournament.teams = create_list(:team, number_of_teams + 1) }
 
           it { is_expected.to be_invalid }
+        end
+
+        context "when greater than to the current number of teams" do
+          before { tournament.teams = create_list(:team, number_of_teams - 1) }
+
+          it { is_expected.to be_valid }
         end
       end
     end

--- a/spec/services/build_tournament_rounds_spec.rb
+++ b/spec/services/build_tournament_rounds_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe BuildTournamentRounds do
+  describe "#perform" do
+    subject(:run_service) do
+      service.perform
+    end
+
+    let(:service) { described_class.new(tournament) }
+    let(:tournament) { build(:tournament, :with_teams, number_of_teams: number_of_teams) }
+    let(:first_round) { tournament.rounds.first }
+
+    context "when the number of teams is a power of two" do
+      let(:number_of_teams) { 8 }
+      let(:number_of_rounds) { 3 }
+
+      it "builds the right number of rounds" do
+        expect { run_service }.to change { tournament.rounds.length }.to eq(number_of_rounds)
+      end
+
+      it "builds the right number of matches in the first round" do
+        run_service
+        expect(first_round.matches.length).to eq(number_of_teams / 2)
+      end
+
+      it "does not build any matches in later rounds" do
+        run_service
+        expect(tournament.rounds[1..-1].map(&:matches)).to all(be_empty)
+      end
+    end
+
+    context "when the number of teams is even" do
+      let(:number_of_teams) { 6 }
+      let(:number_of_rounds) { 3 }
+
+      it "builds the right number of rounds" do
+        expect { run_service }.to change { tournament.rounds.length }.to eq(number_of_rounds)
+      end
+
+      it "builds the right number of matches in the first round" do
+        run_service
+        expect(first_round.matches.length).to eq(2)
+      end
+
+      it "builds the right number of matches in the second round" do
+        run_service
+        expect(tournament.rounds[1].matches.length).to eq(1)
+      end
+    end
+
+    context "when the number of teams is odd" do
+      let(:number_of_teams) { 11 }
+      let(:number_of_rounds) { 4 }
+
+      it "builds the right number of rounds" do
+        expect { run_service }.to change { tournament.rounds.length }.to eq(number_of_rounds)
+      end
+
+      it "builds the right number of matches in the first round" do
+        run_service
+        expect(first_round.matches.length).to eq(3)
+      end
+
+      it "builds the right number of matches in the second round" do
+        run_service
+        expect(tournament.rounds[1].matches.length).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/services/update_match_spec.rb
+++ b/spec/services/update_match_spec.rb
@@ -7,19 +7,19 @@ RSpec.describe UpdateMatch do
     end
 
     let(:service) { described_class.new(match, params: params) }
-    let(:params) { { team_one_score: 0, team_two_score: 0 } }
-    let(:update_match) { instance_double("UpdateMatchAttributes") }
+    let(:params) { { team_one_score: 1, team_two_score: 0 } }
+    let(:update_match_attributes) { instance_double("UpdateMatchAttributes") }
 
     before do
-      allow(UpdateMatchAttributes).to receive(:new).and_return(update_match)
-      allow(update_match).to receive(:perform)
+      allow(UpdateMatchAttributes).to receive(:new).and_return(update_match_attributes)
+      allow(update_match_attributes).to receive(:perform)
     end
 
     context "outside a tournament" do
       let(:match) { build(:match) }
 
       it "performs an update" do
-        expect(update_match).to receive(:perform)
+        expect(update_match_attributes).to receive(:perform)
         run_service
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe UpdateMatch do
       let(:end_tournament) { instance_double(EndTournament) }
 
       before do
-        expect(update_match).to receive(:perform)
+        expect(update_match_attributes).to receive(:perform)
       end
 
       it "performs an update" do
@@ -40,20 +40,43 @@ RSpec.describe UpdateMatch do
       end
 
       context "when match is not the last one" do
-        context "when the other match in pair is complete" do
-          it "builds the next match" do
-            expect(CreateNextMatch).to receive(:new).and_return(create_next_match)
-            expect(create_next_match).to receive(:perform)
-            run_service
+        context "when the number of teams is even" do
+          context "when the other match in pair is complete" do
+            it "builds the next match" do
+              expect(CreateNextMatch).to receive(:new).and_return(create_next_match)
+              expect(create_next_match).to receive(:perform)
+              run_service
+            end
+          end
+
+          context "when the other match in pair is not complete" do
+            before { round.matches[1].update!(team_one_score: nil, team_two_score: 1) }
+
+            it "does not build the next match" do
+              allow(CreateNextMatch).to receive(:new).and_return(create_next_match)
+              expect(create_next_match).not_to receive(:perform)
+              run_service
+            end
           end
         end
 
-        context "when the other match in pair is not complete" do
-          before { round.matches[1].update!(team_one_score: nil, team_two_score: 1) }
+        context "when the number of teams is odd" do
+          let(:tournament) { build(:tournament, :with_teams, number_of_teams: 5) }
 
-          it "does not build the next match" do
-            allow(CreateNextMatch).to receive(:new)
-            expect(create_next_match).not_to receive(:perform)
+          before do
+            rounds = Array.new(2) { |i| build(:round, tournament: tournament, number: i) }
+            rounds.first.matches << build(
+              :match,
+              team_one: tournament.teams[0],
+              team_two: tournament.teams[1],
+              played_after: tournament.started_at,
+            )
+            tournament.rounds = rounds
+          end
+
+          it "builds the next match" do
+            allow(CreateNextMatch).to receive(:new).and_return(create_next_match)
+            expect(create_next_match).to receive(:perform)
             run_service
           end
         end


### PR DESCRIPTION
When the number of teams is not a power of two, the initial round is built differently so that the number of teams that play in the second round is a power of two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pczarn/gameroom-task/22)
<!-- Reviewable:end -->
